### PR TITLE
eslint: Add missing `space-before-keywords`

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
         "quotes": 0,
         "semi": [2, "always"],
         "curly": 0,
+        "space-before-keywords": 2,
         "space-before-function-paren": [2, {"anonymous": "always",
                                             "named": "never"}],
         "comma-dangle": 0,


### PR DESCRIPTION
The default airbnb rules miss the `space-before-keywords` one. This
means that code like this is currently considered OK:

```
try {
}catch (e) {  // no space before 'catch'
}

if (cond) {
}else {       // no space before 'else'
}
```

This patchs adds the prementioned rule as an error.
