### PR TITLE
Markdown linter: Fix three annoying/buggy rules

### DIFF
--- a/bin/mdlint.js
+++ b/bin/mdlint.js
@@ -10,6 +10,7 @@ const files = commander.parse(process.argv).args;
 // See rules at https://github.com/mivok/markdownlint/blob/master/docs/RULES.md
 const config = {
     "MD004": false,  // Unordered list style
+    "MD007": false,  // Unordered list indentation
     "MD024": false,  // Multiple headers with the same content
     "MD027": false,  // Multiple spaces after blockquote symbol
     "MD029": { "style": "ordered" }, // Ordered list item prefix


### PR DESCRIPTION
Remove rule MD024 from linter checks. This means that having multiple
markdown headers with the same title will not be a problem anymore.
This was annoying for documents like this (example taken from
IronMan-Vault):

``` md
# Vault API

## Data Structures

### Account

### User

### Role

## Database

### Account

### User

### Role
```

Drawback: anchors generated by GitHub (to allow creating URLs pointing
directly to a paragraph) will collide for headers with the same label.
