### PR TITLE
eslint: Disallow mixed spaces and tabs for indentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     "rules": {
         "strict": [2, "global"],
         "indent": [2, 4],
+        "no-mixed-spaces-and-tabs": 2,
         "max-len": [2, 80, 4],
         "quotes": 0,
         "semi": [2, "always"],


### PR DESCRIPTION
The "no-mixed-spaces-and-tabs" rule seems to be missing from airbnb
linting rules. Consequently, mixed tabulations and spaces in
indentation is not detected by our linter. This was revealed by the
"dev/CLEANUP/IAM_API_OOP" pull request on IronMan-Vault.

This patch adds "no-mixed-spaces-and-tabs" as an error in eslint
configuration. This problem is also currently being reported upstream
to fix airbnb default config: https://github.com/airbnb/javascript/pull/561.
