### PR TITLE
eslint: Only one newline at end of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = {
         "id-length": 0,
         "no-shadow": 0,
         "valid-jsdoc": 1,
-        "eol-last": 2
+        "eol-last": 2,
+        "no-multiple-empty-lines": [ 2, { "max": 2, "maxEOF": 1 } ]
     }
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "babel-eslint": "^4.1.3",
-        "eslint": "^1.5.1",
+        "eslint": "^1.8.0",
         "eslint-config-airbnb": "^0.0.9"
     },
     "keywords": [


### PR DESCRIPTION
POSIX standard states that the last line of a file should end with a
newline character '\n' [1](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206). Conventions generally agree on having only
one newline character at the end of files.

This patchs enables a new rule I contributed in eslint [2](https://github.com/eslint/eslint/pull/4266) to have one
and only one newline at the end of files.
