### PR TITLE
eslint: Forbid usage of console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
         "no-shadow": 0,
         "valid-jsdoc": 1,
         "eol-last": 2,
-        "no-multiple-empty-lines": [ 2, { "max": 2, "maxEOF": 1 } ]
+        "no-multiple-empty-lines": [ 2, { "max": 2, "maxEOF": 1 } ],
+        "no-console": 2,
     }
 };


### PR DESCRIPTION
Writing `console.log()` messages are meant for debugging purposes and
therefore not suitable to ship to the client.

Now that every project had time to remove its `console.log()`
occurences, we can consider its usage as an error (today it's only a
warning).
