### PR TITLE
BF: Add guidelines for logging exception objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -704,7 +704,7 @@ log.debug('computing request signature', { accessKeyId, date, algorithm });
 log.info(`host ${server} is down!`);
 // good
 log.error('bucket metadata update failed',
-          { bucketName, server, errorCode: err.code });
+          { bucketName, server, error: errorObject });
 ```
 
 #### Fields
@@ -726,6 +726,7 @@ non-exhaustive list of field names to use:
   * `endpoint` (can be any service endpoint formatted as `address:port` for
     remote service such as `bucketd`, `vaultd`, `repd`, etc)
   * `method` (method being called in an API)
+  * `error` (as an `arsenal.errors.ArsenalError` object)
 * S3 specific
   * `clientIP`
   * `namespace`


### PR DESCRIPTION
This will avoid inconsistencies such as `err` or `error` attributes
containing either error messages, codes or objects, which can confuse
elasticsearch indices by having conflicting types for fields.
