### PR TITLE
chore(*): update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,5 +54,6 @@ module.exports = {
         'no-return-assign': [1, 'always'],
         'prefer-const': 1,
         'array-callback-return': 1,
+        'no-underscore-dangle': 0,
     },
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 module.exports = {
-    extends: 'airbnb/base',
+    extends: [
+        'eslint-config-airbnb-base',
+        'eslint-config-airbnb-base/rules/strict',
+    ],
 
     env: {
         browser: false,

--- a/index.js
+++ b/index.js
@@ -55,5 +55,6 @@ module.exports = {
         'prefer-const': 1,
         'array-callback-return': 1,
         'no-underscore-dangle': 0,
+        'newline-per-chained-call': 0,
     },
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "url": "https://github.com/scality/IronMan-Guidelines"
     },
     "dependencies": {
-        "babel-eslint": "^6.0.0",
         "commander": "^1.3.2",
         "eslint": "2.9.0",
         "eslint-config-airbnb-base": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     },
     "devDependencies": {
         "babel-eslint": "^6.0.0",
-        "eslint": "^2.4.0",
-        "eslint-config-airbnb": "^6.1.0"
+        "eslint": "2.9.0",
+        "eslint-config-airbnb-base": "3.0.1",
+        "eslint-plugin-import": "1.7.0"
     },
     "keywords": [
         "eslint",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "commander": "^1.3.2",
-        "markdownlint": "^0.0.8"
+        "markdownlint": "0.1.1"
     },
     "devDependencies": {
         "babel-eslint": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,12 @@
         "url": "https://github.com/scality/IronMan-Guidelines"
     },
     "dependencies": {
-        "commander": "^1.3.2",
-        "markdownlint": "0.1.1"
-    },
-    "devDependencies": {
         "babel-eslint": "^6.0.0",
+        "commander": "^1.3.2",
         "eslint": "2.9.0",
         "eslint-config-airbnb-base": "3.0.1",
-        "eslint-plugin-import": "1.7.0"
+        "eslint-plugin-import": "1.7.0",
+        "markdownlint": "0.1.1"
     },
     "keywords": [
         "eslint",


### PR DESCRIPTION
### chore(eslint): switch to airbnb-base       
Since we do not use react, we have no need for react lints.

### chore(npm): update markdownlint

### chore(npm): move eslint to main dependencies
This allows us to make airbnb rules enclosed in our guidelines,
circumventing the need to update every project

### chore(eslint): remove dangling underscore rule
We want to keep bindings privacy explicit in our applications

### chore(npm): remove babel-eslint dependency
`eslint` is now able to parse es6 syntax by default, effectively making
this a non-dependency.

### fix(eslint): disable newline-per-chained-call
The reason behind it is that our 80 columns limitation already
acts as a good limitation. The dodgy detection doesn't help keeping it
either.
