### PR TITLE
Add linter rule forbidding .only for mocha tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ module.exports = {
         mocha: true,
     },
 
+    plugins: [
+        "mocha",
+    ],
+
     rules: {
         'strict': [2, 'global'],
         'indent': [2, 4],
@@ -51,5 +55,6 @@ module.exports = {
         'no-return-assign': [1, 'always'],
         'prefer-const': 1,
         'array-callback-return': 1,
+        "mocha/no-exclusive-tests": 2,
     },
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
         "type": "git",
         "url": "https://github.com/scality/Guidelines"
     },
+    "peerDependencies": {
+        "eslint-plugin-mocha": "^3.0.0"
+    },
     "dependencies": {
         "commander": "^1.3.2",
         "markdownlint": "^0.0.8"


### PR DESCRIPTION
Add linter rule forbidding .only for mocha tests

see https://github.com/scality/Guidelines/pull/49
