### PR TITLE
Chore: upgrade eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: 'airbnb/base',
+    extends: 'airbnb-base',
 
     env: {
         browser: false,
@@ -9,15 +9,64 @@ module.exports = {
 
     rules: {
         'strict': [2, 'global'],
-        'indent': [2, 4],
+
+        // Testing changes:
+        'indent': 'off',
+        'indent-legacy': [2, 4],
+        'no-underscore-dangle': 'off',
+        'no-plusplus': 'off',
+        'object-property-newline': 0,
+        'comma-dangle': ['error', {
+            arrays: 'always-multiline',
+            objects: 'always-multiline',
+            imports: 'always-multiline',
+            exports: 'always-multiline',
+            functions: 'never',
+        }],
+        'new-parens': 'off',
+        'lines-around-directive': 'off',
+        'newline-per-chained-call': 'off',
+        'no-mixed-operators': 'off',
+        'no-continue': 'off',
+        'no-bitwise': 'off',
+        'dot-location': 'off',
+        'space-unary-ops': [2, {
+            words: true, // default: requires space after word unary
+            nonwords: false,  // default: does not require space after op unary
+        }],
+        'import/newline-after-import': 'off',
+        'class-methods-use-this': 'off',
+        'spaced-comment': 'off',
+        'no-multi-spaces': 'off',
+        'no-restricted-properties': 'off',
+        'no-restricted-syntax': 'off',
+        'valid-typeof': 'off',
+        'no-extra-boolean-cast': 'off',
+        'no-template-curly-in-string': 'off',
+        'symbol-description': 'off',
+        'function-paren-newline': 'off',
+        'object-curly-newline': 'off',
+        'prefer-destructuring': 'off',
+        'padded-blocks': 'off',
+        'global-require': 'off',
+        'import/no-dynamic-require': 'off',
+        'no-undef-init': 'off',
+        'switch-colon-spacing': 'off',
+        'no-useless-return': 'off',
+        'no-lonely-if': 'off',
+        'prefer-spread': 'off',
+        'import/no-extraneous-dependencies': 'off',
+        // End of testing changes
+
         'no-mixed-spaces-and-tabs': 2,
         'max-len': [2, 80, 4],
         'quotes': [1, 'single', 'avoid-escape'],
         'semi': [2, 'always'],
         'curly': 1,
-        'space-before-function-paren': [2, { anonymous: 'always',
-                                             named: 'never' }],
-        'comma-dangle': 2,
+        'space-before-function-paren': [2, {
+            anonymous: 'always',
+            named: 'never',
+        }],
         'camelcase': [2, { properties: 'always' }],
         'id-length': 0,
         'no-shadow': 0,

--- a/package.json
+++ b/package.json
@@ -1,40 +1,40 @@
 {
-    "name": "eslint-config-scality",
-    "version": "1.1.0",
-    "description": "ESLint config for Scality's Node.js coding guidelines",
-    "bin": {
-        "mdlint": "./bin/mdlint.js"
-    },
-    "main": "index.js",
-    "scripts": {
-        "test": "npm run --silent lint && npm run --silent lint_md",
-        "lint": "node_modules/.bin/eslint -c index.js $(git ls-files '*.js')",
-        "lint_md": "node bin/mdlint.js $(git ls-files '*.md')"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/scality/Guidelines"
-    },
-    "dependencies": {
-        "commander": "^1.3.2",
-        "markdownlint": "^0.0.8"
-    },
-    "devDependencies": {
-        "babel-eslint": "^6.0.0",
-        "eslint": "^2.4.0",
-        "eslint-config-airbnb": "^6.1.0"
-    },
-    "keywords": [
-        "eslint",
-        "eslintconfig",
-        "config",
-        "airbnb",
-        "scality",
-        "javascript",
-        "markdown",
-        "styleguide"
-    ],
-    "author": "Giorgio Regni",
-    "license": "Apache-2.0",
-    "homepage": "https://github.com/scality/Guidelines"
+  "name": "eslint-config-scality",
+  "version": "1.1.0",
+  "description": "ESLint config for Scality's Node.js coding guidelines",
+  "bin": {
+    "mdlint": "./bin/mdlint.js"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run --silent lint && npm run --silent lint_md",
+    "lint": "node_modules/.bin/eslint -c index.js $(git ls-files '*.js')",
+    "lint_md": "node bin/mdlint.js $(git ls-files '*.md')"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scality/Guidelines"
+  },
+  "dependencies": {
+    "commander": "^1.3.2",
+    "markdownlint": "^0.0.8"
+  },
+  "devDependencies": {
+    "eslint": "4.6.0",
+    "eslint-config-airbnb-base": "12.0.0",
+    "eslint-plugin-import": "2.7.0"
+  },
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "config",
+    "airbnb",
+    "scality",
+    "javascript",
+    "markdown",
+    "styleguide"
+  ],
+  "author": "Giorgio Regni",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/scality/Guidelines"
 }


### PR DESCRIPTION
Attempting to upgrade Eslint version. New version has pretty stringent rules in-place, so a lot of additional rules were added here.

- Added `eslint-plugin`import` as the airbnb linter needed it.
- Using `indent-legacy` for easier version transition, utilizing mostly same indent rules as we had in version 2.

List of Eslint rules: https://eslint.org/docs/rules/

Note: I will clean up inline comments and squash commits after any recommended changes
Note: I am using atom, and I updated linter versions to the following. Don't know if this matters honestly:
    - linter 2.2.0
    - linter-eslint 8.2.1
    - linter-ui-default 1.6.8
