### PR TITLE
docs: update contrib guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,8 +270,8 @@ conditions:
 * Provide one and only one feature/bugfix/meaningful change
 * Provide working unit and functional tests associated to the change.
 
-The commit message shall follow a **standardized formatting, that will be checked
-automatically by a VCS hook on the commit**.
+The commit message shall follow a **standardized formatting,
+that will be checked automatically by a VCS hook on the commit**.
 
 The first line of the commit message (often called the one-liner) shall
 provide the essential information about the commit itself. **It must thus
@@ -287,7 +287,8 @@ If more details seem necessary or useful, one line must be left empty
 (to follow the consensual git commit way), and either a paragraph,
 a list of items, or both can be written to provide insight into the
 details of the commit. Those details can include describing the workings
-of the change, explain a design choice, or providing a tracker reference (issue number or bugreport link).
+of the change, explain a design choice, or providing a tracker reference
+(issue number or bugreport link).
 
 ```ascii
 Related to issue #245

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Guidelines
 
-[![CircleCI][badgepub]](https://circleci.com/gh/scality/Guidelines)
-[![Scality CI][badgepriv]](http://ci.ironmann.io/gh/scality/Guidelines)
-
 This project:
 
 * Defines and explains the coding style and workflow for the S3 project. See
@@ -11,6 +8,3 @@ This project:
 * Provides an `eslint-config-scality` package that can be added as a dependency
   in other projects. That way, coding style can automatically be checked using
   eslint.
-
-[badgepub]: https://circleci.com/gh/scality/Guidelines.svg?style=svg
-[badgepriv]: http://ci.ironmann.io/gh/scality/Guidelines.svg?style=svg&circle-token=ea58a3cc28f0d01eb9f596ab2e44f065ef1d10f7


### PR DESCRIPTION
Fixes: ZENKOIO-135

Updating the release engineering process description(GitWaterFlow)
Fix some contributor's guidelines like branch naming, formatting of commits, etc...