### PR TITLE
improvement: S3C-3098 support of async/await by eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 module.exports = {
     extends: 'airbnb/base',
 
+    parserOptions: {
+        ecmaVersion: 8,
+    },
+
     env: {
         browser: false,
         node: true,
@@ -47,7 +51,7 @@ module.exports = {
         'arrow-body-style': [1, 'as-needed'],
         'prefer-rest-params': 1,
         'no-unneeded-ternary': [1, { defaultAssignment: false }],
-        'arrow-parens': [1, 'as-needed'],
+        'arrow-parens': 0,
         'no-return-assign': [1, 'always'],
         'prefer-const': 1,
         'array-callback-return': 1,


### PR DESCRIPTION
Add the needed parserOption.ecmaVersion=8 parameter to support
async/await syntax in other repositories.

Remove arrow-parens rule as it gives false positives when using
"async" keyword on arrow function.
