### PR TITLE
Fix eslint to properly detect brace-less one-line if

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
         'max-len': [2, 120, 4],
         'quotes': [1, 'single', 'avoid-escape'],
         'semi': [2, 'always'],
-        'curly': 1,
+        'curly': [1, 'all'],
         'space-before-function-paren': [
             2,
             { anonymous: 'always', named: 'never' },


### PR DESCRIPTION
The current config, inherited from airbnb's bestpractices, allows
brace-less one-line if, which are not allowed in the guidelines:

```
if (fooo) do_something();
```

This PR fixes eslint config to make it consistent with the guidelines doc, and prevent this kind of code.