### PR TITLE
GDL-9 publish npm package to registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to be released'
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  check:
+    name: preliminary-checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure version is properly set
+        run: |
+          test "$(npm -s run get-version)" = "${{ inputs.tag }}"
+      - name: Give user instruction
+        if: failure()
+        run: echo "::error file=package.json,line=6::The tag ${{ inputs.tag }} must match the version"
+  publish-github:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: '16'
+          registry-url: 'https://npm.pkg.github.com'
+      - run: yarn install
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npmjs.org
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  release-github:
+    runs-on: ubuntu-latest
+    needs:
+    - publish-github
+    - publish-npm
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: Release ${{ inputs.tag }}
+          target_commitish: ${{ github.sha }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "eslint-config-scality",
+    "name": "@scality/guidelines",
     "version": "7.10.2",
     "description": "ESLint config for Scality's Node.js coding guidelines",
     "bin": {
@@ -39,5 +39,8 @@
     "homepage": "https://github.com/scality/Guidelines",
     "engines": {
         "node": ">=16"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
Release workflow that will publish `guidelines` as `@scality/guidelines` on both GitHub Packages and Npmjs.org.

I recommend us to spend some time here as this will kind of set the picture for the rest of our packages, the work will be pretty much a copy paste from here.

Publishing on GitHub Packages could arguably be optional, but I believe it helps with some internal discovery things like dependabot or security. Additionally, I believe that privates one will be published into GitHub Packages, so at least all of our packages will be with one registry if it's something we will look into in the future. 

The most important one to set it's npmjs.org. because even though we can host public packages under the GitHub umbrella, it still enforces users to login with GitHub to be able to pull them, and I'm afraid this some unnecessary complexity, which may break scripts, or user workflows, etc.