### PR TITLE
GDL-9 publish npm package to registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+---
+name: Release
+
+run-name: release ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to be released'
+        required: true
+
+jobs:
+  publish:
+    permissions:
+      packages: write
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set env vars
+        run: |
+          echo PKG_VERSION="$(jq -r .version < package.json)" >> $GITHUB_ENV
+          echo PKG_NAME="$(jq -r .name < package.json)" >> $GITHUB_ENV
+          echo PKG_BASENAME="$(basename $(jq -r .name < package.json))" >> $GITHUB_ENV
+      - name: Ensure the branch is protected
+        run: |
+          if [[ "${{ github.ref_protected }}" = "false" ]]; then
+            echo "::error::The branch ${{ github.ref }} is not protected"
+            exit 1
+          fi
+      - name: Ensure tag has not been released
+        run: |
+          TAG_EXISTS=$(git tag -l "${{ inputs.tag }}")
+          if [[ -n "$TAG_EXISTS" ]]; then
+            echo "::error::The tag ${{ inputs.tag }} already exists"
+            exit 1
+          fi
+      - name: Ensure version is properly set
+        run: |
+           if ! [[ "$PKG_VERSION" = "$VERSION" ]]; then
+             echo "::error file=package.json,line=$(sed -n '/"version":/=' package.json)::The tag $VERSION must match the version $PKG_VERSION specified in package.json"
+             exit 1
+           fi
+      - name: Setup node with GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: '16'
+          registry-url: https://npm.pkg.github.com
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Publish to GitHub Packages
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup node with npmjs.org
+        uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org
+      - name: Publish to npmjs.org
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: Release ${{ inputs.tag }}
+          target_commitish: ${{ github.sha }}
+          append_body: |
+            Github Packages: https://github.com/${{ github.repository }}/pkgs/npm/${{ env.PKG_BASENAME }}
+            npmjs: https://www.npmjs.com/package/${{ env.PKG_NAME }}/v/${{ env.PKG_VERSION }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,20 +4,39 @@ name: tests
 on:
   push:
     branches-ignore:
-    - 'development/**'
+      - q/*/*
 
 jobs:
   test:
+    permissions:
+      packages: write
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-    - name: install dependencies
-      run: yarn install --frozen-lockfile
-    - name: lint markdown
-      run: yarn lint_md
-    - name: lint javascript
-      run: yarn lint
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+          registry-url: https://npm.pkg.github.com
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: lint markdown
+        run: yarn lint_md
+      - name: lint javascript
+        run: yarn lint
+      - name: Set common env vars for npm publish
+        run: |
+          echo "SHORTSHA=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+          echo "PKG_VERSION=$(jq -r .version < package.json)" >> $GITHUB_ENV
+      - name: Set version for work in progress
+        run: yarn version --no-git-tag-version --new-version "0.0.0-sha.${SHORTSHA}"
+        if: github.ref_protected == false
+      - name: Set version for protected branch
+        run: yarn version --no-git-tag-version --new-version "${PKG_VERSION}-sha.${SHORTSHA}"
+        if: github.ref_protected
+      - name: Publish development version
+        run: npm publish --provenance --tag "${{ github.ref_name }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -1,23 +1,26 @@
 {
-    "name": "eslint-config-scality",
+    "name": "@scality/eslint-config",
     "version": "7.10.2",
     "description": "ESLint config for Scality's Node.js coding guidelines",
     "bin": {
-        "mdlint": "./bin/mdlint.js"
+        "mdlint": "bin/mdlint.js"
     },
     "main": "index.js",
     "scripts": {
         "test": "npm run --silent lint && npm run --silent lint_md",
-        "lint": "node_modules/.bin/eslint -c index.js $(git ls-files '*.js')",
+        "lint": "eslint -c index.js $(git ls-files '*.js')",
         "lint_md": "node bin/mdlint.js $(git ls-files '*.md')"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/scality/Guidelines"
+        "url": "git+https://github.com/scality/Guidelines.git"
     },
     "dependencies": {
         "commander": "1.3.2",
         "markdownlint": "^0.25.1"
+    },
+    "bugs": {
+        "url": "https://github.com/scality/Guidelines/issues"
     },
     "devDependencies": {
         "babel-eslint": "6.1.2",
@@ -25,19 +28,22 @@
         "eslint-config-airbnb": "6.2.0"
     },
     "keywords": [
-        "eslint",
         "eslintconfig",
-        "config",
-        "airbnb",
-        "scality",
         "javascript",
-        "markdown",
+        "scality",
         "styleguide"
     ],
-    "author": "Giorgio Regni",
+    "author": "Scality Object Squad <object-squad@scality.com>",
     "license": "Apache-2.0",
     "homepage": "https://github.com/scality/Guidelines",
     "engines": {
         "node": ">=16"
-    }
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "bin",
+        "*.[c]js"
+    ]
 }


### PR DESCRIPTION


Release workflow that will publish `guidelines` as `@scality/guidelines` on both GitHub Packages and Npmjs.org.

I recommend us to spend some time here as this will kind of set the picture for the rest of our packages, the work will be pretty much a copy paste from here.

Publishing on GitHub Packages could arguably be optional, but I believe it helps with some internal discovery things like dependabot or security. Additionally, I believe that privates one will be published into GitHub Packages, so at least all of our packages will be with one registry if it's something we will look into in the future.

The most important one to set it's npmjs.org. because even though we can host public packages under the GitHub umbrella, it still enforces users to login with GitHub to be able to pull them, and I'm afraid this some unnecessary complexity, which may break scripts, or user workflows, etc.
