### PR TITLE
Set Prettier quoteProps to consistent to match eslint quote-props

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project:
 This repository also provides a **baseline Prettier configuration** for Scality
 object repositories: 4-space JavaScript/TypeScript indentation, 120-character
 line length, single quotes, semicolons, trailing commas, and
-`quoteProps: 'as-needed'`.
+`quoteProps: 'consistent'`.
 
 The configuration lives in `prettier.config.cjs`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-config-scality",
-    "version": "8.3.2",
+    "version": "8.3.3",
     "description": "ESLint config for Scality's Node.js coding guidelines",
     "bin": {
         "mdlint": "./bin/mdlint.js",

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
     useTabs: false,
     printWidth: 120,
     singleQuote: true,
-    quoteProps: 'as-needed',
+    quoteProps: 'consistent',
     semi: true,
     trailingComma: 'all',
     arrowParens: 'avoid',


### PR DESCRIPTION
## What

Change the shared Prettier config `quoteProps` from `'as-needed'` to `'consistent'` (and the matching README line), then bump to `8.3.3`.

## Why

`@scality/eslint-config-scality` ships a Prettier config whose `quoteProps: 'as-needed'` contradicts the package's own ESLint rule `quote-props: 'consistent-as-needed'` — which has been in place since 2016. On objects with mixed keys (some requiring quotes, e.g. `'content-md5'`, others not, e.g. `expires`), Prettier `as-needed` produces mixed quoting that ESLint `consistent-as-needed` then rejects (*"Inconsistently quoted property"*). Any repo running **both** Prettier (via `scality-prettier-diff`) and ESLint over the same file therefore gets conflicting requirements and cannot satisfy both.

Setting Prettier to `'consistent'` makes its output match the ESLint rule (quote all-or-none). This only affects repos that actually run Prettier — the Prettier config is not consumed by ESLint-only repos — so it is a safe, global reconciliation with no downside for non-Prettier consumers.

## Scope

This resolves the **`quote-props`** half of the ESLint↔Prettier conflict. The other half — ESLint `indent` vs Prettier indentation — cannot be reconciled by config (Prettier exposes no options to match ESLint's `indent` rule) and is handled separately by each Prettier-adopting repo adding `eslint-config-prettier` to its own ESLint config.

## Context

- Full analysis and the broader fix plan: https://scality.atlassian.net/wiki/x/CQDe8
- The contradiction was introduced by GDL-12 (Prettier config added with `as-needed`) against the 2016 ESLint `quote-props` rule, and armed as a CI check by GDL-14 (`scality-prettier-diff`).
- First surfaced by Arsenal ARSN-572 — the first PR to touch a previously-unformatted `.ts` file in a Prettier-enforcing repo.

Issue: GDL-15